### PR TITLE
Fix Copy URL: Use a different way to copy to users' clipboard

### DIFF
--- a/public/modules/dashboards/services/share.client.service.js
+++ b/public/modules/dashboards/services/share.client.service.js
@@ -60,14 +60,11 @@ angular.module("dashboards").factory("shareService", [
       return location.href + "?country=" + countryCode;
     }
 
-    function copyToClipboard(text) {
-      var tempInput = document.createElement("input");
+    function copyToClipboard() {
+      var containerElement = document.getElementById("share-url-container");
 
-      document.body.append(tempInput);
-      tempInput.value = text;
-      tempInput.select();
+      containerElement.select();
       document.execCommand("copy");
-      tempInput.parentNode.removeChild(tempInput);
     }
 
     return {

--- a/public/modules/dashboards/views/community_risk.client.view.html
+++ b/public/modules/dashboards/views/community_risk.client.view.html
@@ -680,12 +680,14 @@
             {{ "share_url_title" | translate }}
           </h2>
         </div>
-        <div class="modal-body" style="word-break:break-all">
-          <pre><a href="{{ shareable_URL }}">{{ shareable_URL }}</a></pre>
+        <div class="modal-body">
+          <pre><textarea rows="2"
+                         id="share-url-container"
+                         class="form-control">{{ shareable_URL }}</textarea></pre>
           <button
             type="button"
-            ng-click="copyToClipboard(shareable_URL)"
-            class="btn btn-default"
+            ng-click="copyToClipboard()"
+            class="btn btn-primary"
           >
             {{ "share_url_copy" | translate }}
           </button>

--- a/public/modules/dashboards/views/fbf.client.view.html
+++ b/public/modules/dashboards/views/fbf.client.view.html
@@ -580,12 +580,14 @@
             {{ "share_url_title" | translate }}
           </h2>
         </div>
-        <div class="modal-body" style="word-break:break-all">
-          <pre><a href="{{ shareable_URL }}">{{ shareable_URL }}</a></pre>
+        <div class="modal-body">
+          <pre><textarea rows="2"
+                         id="share-url-container"
+                         class="form-control">{{ shareable_URL }}</textarea></pre>
           <button
             type="button"
-            ng-click="copyToClipboard(shareable_URL)"
-            class="btn btn-default"
+            ng-click="copyToClipboard()"
+            class="btn btn-primary"
           >
             {{ "share_url_copy" | translate }}
           </button>

--- a/public/modules/dashboards/views/impact_database.client.view.html
+++ b/public/modules/dashboards/views/impact_database.client.view.html
@@ -585,12 +585,14 @@
             {{ "share_url_title" | translate }}
           </h2>
         </div>
-        <div class="modal-body" style="word-break:break-all">
-          <pre><a href="{{ shareable_URL }}">{{ shareable_URL }}</a></pre>
+        <div class="modal-body">
+          <pre><textarea rows="2"
+                         id="share-url-container"
+                         class="form-control">{{ shareable_URL }}</textarea></pre>
           <button
             type="button"
-            ng-click="copyToClipboard(shareable_URL)"
-            class="btn btn-default"
+            ng-click="copyToClipboard()"
+            class="btn btn-primary"
           >
             {{ "share_url_copy" | translate }}
           </button>

--- a/public/modules/dashboards/views/priority_index.client.view.html
+++ b/public/modules/dashboards/views/priority_index.client.view.html
@@ -571,12 +571,14 @@
             {{ "share_url_title" | translate }}
           </h2>
         </div>
-        <div class="modal-body" style="word-break:break-all">
-          <pre><a href="{{ shareable_URL }}">{{ shareable_URL }}</a></pre>
+        <div class="modal-body">
+          <pre><textarea rows="2"
+                         id="share-url-container"
+                         class="form-control">{{ shareable_URL }}</textarea></pre>
           <button
             type="button"
-            ng-click="copyToClipboard(shareable_URL)"
-            class="btn btn-default"
+            ng-click="copyToClipboard()"
+            class="btn btn-primary"
           >
             {{ "share_url_copy" | translate }}
           </button>


### PR DESCRIPTION
* Less reusable code, but less code overall. :)
* Users of unsupporting browsers can still select the text easily by hand